### PR TITLE
[PKG-8870] structlog 24.4.0 [move to defaults]

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,6 @@ test:
     - pip check
     # check that pip gets the correct version 
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    # - pytest -v tests --asyncio-mode=auto --ignore=tests/test_twisted.py -k "not test_delattr_missing"
     # Skip: test_foreign_pre_chain_filter_by_level
     # In Python 3.13, there was a change (later reverted) that disabled logging during message processing
     # to prevent recursion. The structlog library's filter_by_level processor was updated to handle this by
@@ -50,7 +49,7 @@ test:
     # The test test_foreign_pre_chain_filter_by_level is failing because the current structlog version (24.4.0)
     # has the workaround for the Python 3.13 change, but the test environment might have a logger that's being
     # treated as disabled during the test.
-    # TODO: check for the next verison of structlog
+    # TODO: check for the next version of structlog
     - pytest -v tests  # [py!=313]
     - pytest -v tests -k "not test_foreign_pre_chain_filter_by_level"  # [py==313]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,9 @@
+{% set name = "structlog" %}
 {% set version = "24.4.0" %}
 {% set sha256 = "d85aa814a735cf7d7c4a36ea3052d35ca7b2c631251f20950b1c17eacf1f4651" %}
 
 package:
-  name: structlog
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -11,7 +12,7 @@ source:
 
 build:
   skip: True  # [py<38]
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir --no-build-isolation -v
 
 requirements:
@@ -34,11 +35,24 @@ test:
     - pytest-asyncio >=0.17
   source_files:
     - tests
+    - pyproject.toml
   imports:
     - structlog
   commands:
     - pip check
-    - pytest -v tests --ignore=tests/test_twisted.py -k "not test_delattr_missing"
+    # check that pip gets the correct version 
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    # - pytest -v tests --asyncio-mode=auto --ignore=tests/test_twisted.py -k "not test_delattr_missing"
+    # Skip: test_foreign_pre_chain_filter_by_level
+    # In Python 3.13, there was a change (later reverted) that disabled logging during message processing
+    # to prevent recursion. The structlog library's filter_by_level processor was updated to handle this by
+    # checking not logger.disabled in addition to the level check.
+    # The test test_foreign_pre_chain_filter_by_level is failing because the current structlog version (24.4.0)
+    # has the workaround for the Python 3.13 change, but the test environment might have a logger that's being
+    # treated as disabled during the test.
+    # TODO: check for the next verison of structlog
+    - pytest -v tests  # [py!=313]
+    - pytest -v tests -k "not test_foreign_pre_chain_filter_by_level"  # [py==313]
 
 about:
   home: https://www.structlog.org


### PR DESCRIPTION
structlog 24.4.0

**Destination channel:** defaults

### Links

- [PKG-8870]
- dev_url (anaconda): https://github.com/hynek/structlog/tree/24.4.0
- conda-forge: https://github.com/conda-forge/structlog-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/structlog/24.4.0
- pypi inspector: https://inspector.pypi.io/project/structlog/24.4.0

### Explanation of changes:

> [!IMPORTANT]
> This package was previously (in the same version) present on the Snowflake channel. We are moving it to `defaults/main`.
 
- removed abs.yaml -> this goes now to defaults.
- bump build number to 1.
- enabled all tests (uses pyproject.toml to correctly configure them).
- build for py313 (1 test is disabled: see comment).


[PKG-8870]: https://anaconda.atlassian.net/browse/PKG-8870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ